### PR TITLE
Add NFCom package enums

### DIFF
--- a/src/main/java/com/acbr/nfcom/TipoPathNFCom.java
+++ b/src/main/java/com/acbr/nfcom/TipoPathNFCom.java
@@ -1,0 +1,36 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.acbr.nfcom;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum TipoPathNFCom {
+    NFCom(0),
+    Cancelamento(1);
+
+    private static final Map<Integer, TipoPathNFCom> map;
+    private final int enumValue;
+
+    static {
+        map = new HashMap<>();
+        for (TipoPathNFCom value : TipoPathNFCom.values()) {
+            map.put(value.asInt(), value);
+        }
+    }
+
+    public static TipoPathNFCom valueOf(int value) {
+        return map.get(value);
+    }
+
+    private TipoPathNFCom(int id) {
+        this.enumValue = id;
+    }
+
+    public int asInt() {
+        return enumValue;
+    }
+}

--- a/src/main/java/com/acbr/nfcom/VersaoNFCom.java
+++ b/src/main/java/com/acbr/nfcom/VersaoNFCom.java
@@ -1,0 +1,35 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.acbr.nfcom;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum VersaoNFCom {
+    ve100(0);
+
+    private static final Map<Integer, VersaoNFCom> map;
+    private final int enumValue;
+
+    static {
+        map = new HashMap<>();
+        for (VersaoNFCom value : VersaoNFCom.values()) {
+            map.put(value.asInt(), value);
+        }
+    }
+
+    public static VersaoNFCom valueOf(int value) {
+        return map.get(value);
+    }
+
+    private VersaoNFCom(int id) {
+        this.enumValue = id;
+    }
+
+    public int asInt() {
+        return enumValue;
+    }
+}


### PR DESCRIPTION
## Summary
- add the `nfcom` package following the MDFe example
- provide the `TipoPathNFCom` enum mapping NFCom path options
- include the `VersaoNFCom` enum with the initial supported layout version

## Testing
- ⚠️ `mvn -q -DskipTests package` *(fails: Maven Central unreachable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c856dce6108328b2bfc43c2fc75fe5